### PR TITLE
Comparable Enum Screen

### DIFF
--- a/AssistantKit/Classes/Screen.swift
+++ b/AssistantKit/Classes/Screen.swift
@@ -20,7 +20,7 @@ import UIKit
  - Parameter Inches_9_7:    Screens for iPad
  - Parameter Inches_12_9:   Screens for iPad Pro
  */
-public enum Screen: CGFloat {
+public enum Screen: CGFloat, Comparable {
     case unknown     = 0
     case inches_3_5  = 3.5
     case inches_4_0  = 4.0
@@ -46,6 +46,26 @@ public enum Screen: CGFloat {
             return .Unknown
         }
     }
+}
+
+public func ==(lhs: Screen, rhs: Screen) -> Bool {
+    return lhs.rawValue == rhs.rawValue
+}
+
+public func <(lhs: Screen, rhs: Screen) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+}
+
+public func <=(lhs: Screen, rhs: Screen) -> Bool {
+    return lhs.rawValue <= rhs.rawValue
+}
+
+public func >=(lhs: Screen, rhs: Screen) -> Bool {
+    return lhs.rawValue >= rhs.rawValue
+}
+
+public func >(lhs: Screen, rhs: Screen) -> Bool {
+    return lhs.rawValue > rhs.rawValue
 }
 
 /**

--- a/AssistantKit/Classes/Screen.swift
+++ b/AssistantKit/Classes/Screen.swift
@@ -48,6 +48,8 @@ public enum Screen: CGFloat, Comparable {
     }
 }
 
+// Comparing: Screen and Screen
+
 public func ==(lhs: Screen, rhs: Screen) -> Bool {
     return lhs.rawValue == rhs.rawValue
 }
@@ -66,6 +68,28 @@ public func >=(lhs: Screen, rhs: Screen) -> Bool {
 
 public func >(lhs: Screen, rhs: Screen) -> Bool {
     return lhs.rawValue > rhs.rawValue
+}
+
+// Comparing: Screen and Device
+
+public func ==(lhs: Screen, rhs: Version) -> Bool {
+    return lhs == rhs.screen
+}
+
+public func <(lhs: Screen, rhs: Version) -> Bool {
+    return lhs < rhs.screen
+}
+
+public func <=(lhs: Screen, rhs: Version) -> Bool {
+    return lhs <= rhs.screen
+}
+
+public func >=(lhs: Screen, rhs: Version) -> Bool {
+    return lhs >= rhs.screen
+}
+
+public func >(lhs: Screen, rhs: Version) -> Bool {
+    return lhs > rhs.screen
 }
 
 /**

--- a/AssistantKit/Classes/Type.swift
+++ b/AssistantKit/Classes/Type.swift
@@ -62,6 +62,54 @@ public enum Version: String {
     case simulator
 
     case unknown
+    
+    /**
+     Return device screen
+     - Seealso: Screen
+     */
+    public var screen: Screen {
+        switch self {
+        case .podTouch1,
+             .podTouch2,
+             .podTouch3,
+             .podTouch4,
+             .phone4,
+             .phone4S:
+            return .inches_3_5
+        case .podTouch5,
+             .podTouch6,
+             .phone5,
+             .phone5C,
+             .phone5S,
+             .phoneSE:
+            return .inches_4_0
+        case .phone6,
+             .phone6S,
+             .phone7:
+            return .inches_4_7
+        case .phone6Plus,
+             .phone6SPlus,
+             .phone7Plus:
+            return .inches_5_5
+        case .padMini,
+             .padMini2,
+             .padMini3,
+             .padMini4:
+            return .inches_7_9
+        case .pad1,
+             .pad2,
+             .pad3,
+             .pad4,
+             .padAir,
+             .padAir2:
+            return .inches_9_7
+        case .padPro:
+            return .inches_12_9
+        case .simulator,
+             .unknown:
+            return .unknown
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Hey.

Thanks a lot for this awesome framework.

I added `Comparable` protocol to the enum `Screen` in order to do things like:
```
if Device.screen <= .inches_4_7 {
  // do something for all screen sizes equal or lower than 4.7 inches. 
  // example: all iPods, iPhone 4, 4s, 5, 5c, 5s, 6, 6s, 7, etc.
}
```

Also, I added `screen` property in `Version` to achieve things like:
```
if Device.screen < Version.phone5.screen {
  // do something for all screen sizes lower than iPhone 5.
  // example: iPhone 4, 4s, etc.
}
```

Or just:
```
if Device.screen < Version.phone5 {
  // same as before
}
```

What do you think?